### PR TITLE
Fixed Workflow and Added Tests

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]" psycopg2-binary
+          pip install isort
 
       - name: Run isort
         run: isort --check-only .
@@ -63,6 +64,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]" psycopg2-binary
+          pip install flake8
 
       - name: Run flake8
         run: flake8 .

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -39,7 +39,6 @@ jobs:
 
       - name: Run isort
         run: isort --check-only .
-        working-directory: ./src
 
   flake:
     name: flake8
@@ -67,4 +66,3 @@ jobs:
 
       - name: Run flake8
         run: flake8 .
-        working-directory: ./src

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" psycopg2-binary
+          pip install -e ".[dev]" psycopg2-binary pytest
 
       - name: Run tests for exhibitors plugin
-        run: py.test tests --reruns 3
+        run: pytest tests --reruns 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,15 @@
-# put your pytest fixtures here
+import pytest
+from pretix.base.models import Organizer, Event
+from django.utils.timezone import now
+
+@pytest.fixture
+def event(db):
+    organizer = Organizer.objects.create(name="Test Organizer", slug="test-organizer")
+    event = Event.objects.create(
+        organizer=organizer,
+        name="Test Event",
+        slug="test-event",
+        live=True,
+        date_from=now(),
+    )
+    return event

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,95 @@
-def test_empty():
-    from exhibitor.apps import ExhibitorConfig
-    assert ExhibitorConfig.name == 'exhibitor'
-    assert isinstance(ExhibitorConfig.verbose_name, str)
-    assert isinstance(ExhibitorConfig.description, str)
-    assert isinstance(ExhibitorConfig.version, str)
-    assert ExhibitorConfig.author == 'OpenCraft'
+import pytest
+from exhibitors.models import ExhibitorInfo
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+@pytest.mark.django_db
+def test_create_exhibitor_info(event):
+    # CREATE: Simulate an image upload and create an exhibitor
+    logo = SimpleUploadedFile("test_logo.jpg", b"file_content", content_type="image/jpeg")
+    
+    exhibitor = ExhibitorInfo.objects.create(
+        event=event,
+        name="Test Exhibitor",
+        description="This is a test exhibitor",
+        url="http://testexhibitor.com",
+        email="test@example.com",
+        logo=logo,
+        lead_scanning_enabled=True
+    )
+
+    # Verify the exhibitor was created and the fields are correct
+    assert exhibitor.name == "Test Exhibitor"
+    assert exhibitor.description == "This is a test exhibitor"
+    assert exhibitor.url == "http://testexhibitor.com"
+    assert exhibitor.email == "test@example.com"
+    assert exhibitor.logo.name == "exhibitors/logos/Test Exhibitor/test_logo.jpg"
+    assert exhibitor.lead_scanning_enabled is True
+
+@pytest.mark.django_db
+def test_read_exhibitor_info(event):
+    # CREATE an exhibitor first to test reading
+    logo = SimpleUploadedFile("test_logo.jpg", b"file_content", content_type="image/jpeg")
+    exhibitor = ExhibitorInfo.objects.create(
+        event=event,
+        name="Test Exhibitor",
+        description="This is a test exhibitor",
+        url="http://testexhibitor.com",
+        email="test@example.com",
+        logo=logo,
+        lead_scanning_enabled=True
+    )
+
+    # READ: Fetch the exhibitor from the database and verify fields
+    exhibitor_from_db = ExhibitorInfo.objects.get(id=exhibitor.id)
+    assert exhibitor_from_db.name == "Test Exhibitor"
+    assert exhibitor_from_db.description == "This is a test exhibitor"
+    assert exhibitor_from_db.url == "http://testexhibitor.com"
+    assert exhibitor_from_db.email == "test@example.com"
+    assert exhibitor_from_db.lead_scanning_enabled is True
+
+@pytest.mark.django_db
+def test_update_exhibitor_info(event):
+    # CREATE an exhibitor first to test updating
+    logo = SimpleUploadedFile("test_logo.jpg", b"file_content", content_type="image/jpeg")
+    exhibitor = ExhibitorInfo.objects.create(
+        event=event,
+        name="Test Exhibitor",
+        description="This is a test exhibitor",
+        url="http://testexhibitor.com",
+        email="test@example.com",
+        logo=logo,
+        lead_scanning_enabled=True
+    )
+
+    # UPDATE: Modify some fields and save the changes
+    exhibitor.name = "Updated Exhibitor"
+    exhibitor.description = "This is an updated description"
+    exhibitor.lead_scanning_enabled = False
+    exhibitor.save()
+
+    # Verify the updated fields
+    updated_exhibitor = ExhibitorInfo.objects.get(id=exhibitor.id)
+    assert updated_exhibitor.name == "Updated Exhibitor"
+    assert updated_exhibitor.description == "This is an updated description"
+    assert updated_exhibitor.lead_scanning_enabled is False
+
+@pytest.mark.django_db
+def test_delete_exhibitor_info(event):
+    # CREATE an exhibitor first to test deleting
+    logo = SimpleUploadedFile("test_logo.jpg", b"file_content", content_type="image/jpeg")
+    exhibitor = ExhibitorInfo.objects.create(
+        event=event,
+        name="Test Exhibitor",
+        description="This is a test exhibitor",
+        url="http://testexhibitor.com",
+        email="test@example.com",
+        logo=logo,
+        lead_scanning_enabled=True
+    )
+
+    # DELETE: Delete the exhibitor and verify it no longer exists
+    exhibitor_id = exhibitor.id
+    exhibitor.delete()
+
+    with pytest.raises(ExhibitorInfo.DoesNotExist):
+        ExhibitorInfo.objects.get(id=exhibitor_id)


### PR DESCRIPTION
This fixes the failing workflow and added the tests to simulate CRUD operations

## Summary by Sourcery

Fix the failing workflow by updating the test command and dependencies, and add tests to simulate CRUD operations on the ExhibitorInfo model.

Bug Fixes:
- Fix the workflow by correcting the command to run tests using 'pytest' instead of 'py.test'.

CI:
- Update the CI workflow to include 'pytest' in the Python dependencies installation step.

Tests:
- Add comprehensive tests for CRUD operations on the ExhibitorInfo model, including create, read, update, and delete functionalities.
- Introduce a pytest fixture for setting up a test event, which is used in the CRUD tests.