### PR TITLE
Fix Template Error

### DIFF
--- a/exhibitors/signals.py
+++ b/exhibitors/signals.py
@@ -48,13 +48,3 @@ def navbar_info(sender, request, **kwargs):
         ),
         'active': url.namespace == 'plugins:exhibitors',
     }]
-
-
-@receiver(order_info_top, dispatch_uid="exhibitor_info")
-def w_order_info(sender: Event, request, order: Order, **kwargs):
-    template = get_template('eventyay-tickets-video/exhibitor_info.html')
-    ctx = {
-        'order': order,
-        'event': sender,
-    }
-    return template.render(ctx, request=request)


### PR DESCRIPTION
This PR fixes the **Internal Server Error (Template Error)** that occurs when a ticket is booked in test mode.

**wikimedia.eventyay.com**
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/122eb01f-dd30-4bd5-803f-17aaa22e92b4" />


**Local**
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/3b47f16d-78a5-4ffe-bc06-73ab38733cf3" />

## Summary by Sourcery

Bug Fixes:
- Delete the `w_order_info` signal receiver and its template rendering to prevent the template error on test mode ticket bookings.