### PR TITLE
fix(style): update isort to ruff

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,8 +13,8 @@ on:
       - "exhibitors/static/**"
 
 jobs:
-  isort:
-    name: isort
+  ruff:
+    name: ruff
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -36,10 +36,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]" psycopg2-binary
-          pip install isort
+          pip install ruff
 
-      - name: Run isort
-        run: isort --check-only .
+      - name: Run ruff (import sorting)
+        run: ruff check --select I .
 
   flake:
     name: flake8

--- a/exhibitors/models.py
+++ b/exhibitors/models.py
@@ -1,6 +1,7 @@
 import os
 import secrets
 import string
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.models import Event

--- a/exhibitors/urls.py
+++ b/exhibitors/urls.py
@@ -2,12 +2,20 @@ from django.urls import path
 from eventyay.api.urls import event_router
 
 from .api import (
-    ExhibitorAuthView, ExhibitorInfoViewSet, LeadCreateView, LeadRetrieveView,
-    LeadUpdateView, TagListView,
+    ExhibitorAuthView,
+    ExhibitorInfoViewSet,
+    LeadCreateView,
+    LeadRetrieveView,
+    LeadUpdateView,
+    TagListView,
 )
 from .views import (
-    ExhibitorCopyKeyView, ExhibitorCreateView, ExhibitorDeleteView,
-    ExhibitorEditView, ExhibitorListView, SettingsView,
+    ExhibitorCopyKeyView,
+    ExhibitorCreateView,
+    ExhibitorDeleteView,
+    ExhibitorEditView,
+    ExhibitorListView,
+    SettingsView,
 )
 
 urlpatterns = [

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
 from setuptools import setup
 
-
 setup()


### PR DESCRIPTION
This PR updates and style workflow to use `ruff` instead of isort, and makes changes according to ruff test.

## Summary by Sourcery

Switch the style workflow to use Ruff for import sorting and update code style to comply with Ruff.

Enhancements:
- Reformat import statements in exhibitors URLs to match Ruff's import sorting conventions.

Build:
- Update style workflow configuration to install Ruff instead of isort and run `ruff check` for import sorting.

CI:
- Replace the isort GitHub Actions job with a Ruff-based style check for imports.