### PR TITLE
fix(config): fix stale pretix reference and coverage typo in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ exclude = .venv,migrations,.ropeproject,static,_static,build
 combine_as_imports = true
 default_section = THIRDPARTY
 include_trailing_comma = true
-known_third_party = pretix
+known_third_party = eventyay
 known_standard_library = typing
 multi_line_output = 5
 not_skip = __init__.py
@@ -33,7 +33,7 @@ omit = */migrations/*,*/urls.py,*/tests/*
 exclude_lines =
     pragma: no cover
     def __str__
-    der __repr__
+    def __repr__
     if settings.DEBUG
     NOQA
     NotImplementedError


### PR DESCRIPTION
## Summary

Fixes two config issues in `setup.cfg` that were missed during the pretix → eventyay migration.

## Changes

### setup.cfg
- **isort config**: `known_third_party = pretix` → `eventyay` isort still referenced the old package name, causing incorrect import sorting
- **coverage config**: `der __repr__` → `def __repr__`  typo in the coverage exclude pattern meant `__repr__` methods were not being excluded from coverage reports

## Notes

The major test suite and CI workflow fixes (package rename, service containers, workflow updates) have already been merged upstream via #24. This PR addresses only the remaining config issues that were not caught in that rename.
