### PR TITLE
Add tag filtering for exhibitors

### DIFF
--- a/exhibition/templates/exhibitors/exhibitor_info.html
+++ b/exhibition/templates/exhibitors/exhibitor_info.html
@@ -18,6 +18,21 @@
             {% endif %}
         </div>
     {% else %}
+    <div class="panel panel-default">
+    <div class="panel-body">
+        <strong>{% trans "Filter by tag:" %}</strong>
+
+        {% for tag in tags %}
+            <a href="?tag={{ tag.name }}" class="btn btn-default btn-sm">
+                {{ tag.name }}
+            </a>
+        {% empty %}
+            <span class="text-muted">{% trans "No tags available" %}</span>
+        {% endfor %}
+
+        <a href="?" class="btn btn-link btn-sm">{% trans "Clear filter" %}</a>
+    </div>
+</div>
         <p>
             {% if "can_change_event_settings" in request.eventpermset %}
                 <a href="{% url "plugins:exhibition:add" organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-default"><i class="fa fa-plus"></i> {% trans "Add Exhibitor" %}

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -5,11 +5,13 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import DeleteView, ListView
+from django.db.models import Q
+
 from eventyay.control.permissions import EventPermissionRequiredMixin
 from eventyay.control.views import CreateView, UpdateView
 
 from .forms import ExhibitorInfoForm
-from .models import ExhibitorInfo, ExhibitorSettings, generate_booth_id
+from .models import ExhibitorInfo, ExhibitorSettings, ExhibitorTag, generate_booth_id
 
 
 class SettingsView(EventPermissionRequiredMixin, ListView):
@@ -48,13 +50,35 @@ class ExhibitorListView(EventPermissionRequiredMixin, ListView):
     context_object_name = 'exhibitors'
 
     def get_queryset(self):
-        return ExhibitorInfo.objects.filter(event=self.request.event)
+        queryset = ExhibitorInfo.objects.filter(
+            event=self.request.event
+        ).prefetch_related("tags")
+
+        search = (self.request.GET.get("search") or "").strip()
+        tag = self.request.GET.get("tag")
+
+        if tag:
+            queryset = queryset.filter(tags__name__icontains=tag)
+
+        if len(search) >= 2:
+            queryset = queryset.filter(
+                Q(name__icontains=search) |
+                Q(booth_name__icontains=search) |
+                Q(description__icontains=search) |
+                Q(tags__name__icontains=search)
+            ).distinct()
+
+        return queryset
 
     def get_success_url(self) -> str:
         return reverse('plugins:exhibition:index', kwargs={
             'organizer': self.request.event.organizer.slug,
             'event': self.request.event.slug
         })
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["tags"] = ExhibitorTag.objects.all()
+        return context
 
 
 class ExhibitorCreateView(EventPermissionRequiredMixin, CreateView):


### PR DESCRIPTION
This PR adds tag filtering functionality to the exhibitor list.

Users can now filter exhibitors by tags using query parameters
and clickable tag buttons in the UI.

This improves navigation for events with many exhibitors.

## Summary by Sourcery

Add tag-based filtering and search enhancements to the exhibitor list view and expose available tags to the template for UI filtering controls.

New Features:
- Allow filtering exhibitors by tag via query parameters on the exhibitor list view.
- Expose all exhibitor tags to the exhibitor list template and render clickable tag filter buttons in the UI.

Enhancements:
- Extend exhibitor search to include tag names and optimize queries by prefetching related tags.