### PR TITLE
Fix SettingsView to filter exhibitors by current event

### DIFF
--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -18,6 +18,9 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
     context_object_name = 'exhibitors'
     permission = 'can_change_settings'
 
+    def get_queryset(self):
+        return ExhibitorInfo.objects.filter(event=self.request.event)
+
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         settings = ExhibitorSettings.objects.get_or_create(event=self.request.event)[0]


### PR DESCRIPTION
This change ensures that SettingsView only shows exhibitors for the current event. Previously, it could display exhibitors from other events since no filtering was applied.

## Summary by Sourcery

Bug Fixes:
- Prevent SettingsView from displaying exhibitors belonging to other events by scoping the queryset to the current event.