### PR TITLE
Add loading indicator for exhibitor submission form

### DIFF
--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -25,7 +25,7 @@
     </div>
 </nav>
 
-<form action="" method="post" class="form-horizontal" enctype="multipart/form-data">
+<form action="" method="post" class="form-horizontal" enctype="multipart/form-data" id="exhibitor-form">
     {% csrf_token %}
     {% bootstrap_form_errors form %}
 
@@ -53,13 +53,19 @@
         {% bootstrap_field form.comment layout="control" %}
     </fieldset>
 
+    <div id="submission-status" class="alert alert-info" style="display: none; margin-top: 15px;">
+        {% trans "Submitting exhibitor details, please wait..." %}
+    </div>
+
     <div class="form-group submit-group">
-        <button type="submit" class="btn btn-primary btn-save">
-            {% if action == 'edit' %}
-                {% trans "Save changes" %}
-            {% else %}
-                {% trans "Save" %}
-            {% endif %}
+        <button type="submit" class="btn btn-primary btn-save" id="submit-btn">
+            <span id="submit-text">
+                {% if action == 'edit' %}
+                    {% trans "Save changes" %}
+                {% else %}
+                    {% trans "Save" %}
+                {% endif %}
+            </span>
         </button>
         <a class="btn btn-default btn-lg"
            href="{% url 'plugins:exhibition:info' organizer=request.event.organizer.slug event=request.event.slug %}">
@@ -67,4 +73,27 @@
         </a>
     </div>
 </form>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var form = document.getElementById('exhibitor-form');
+        var submitBtn = document.getElementById('submit-btn');
+        var submitText = document.getElementById('submit-text');
+        var statusBox = document.getElementById('submission-status');
+
+        if (form) {
+            form.addEventListener('submit', function () {
+                if (submitBtn) {
+                    submitBtn.disabled = true;
+                }
+                if (submitText) {
+                    submitText.textContent = "{% trans 'Submitting...' %}";
+                }
+                if (statusBox) {
+                    statusBox.style.display = 'block';
+                }
+            });
+        }
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
This PR improves exhibitor submission UX by adding loading feedback during form submission.

Changes:
- Disables the submit button after form submission
- Updates the button text to "Submitting..."
- Displays a status message while the form is being submitted

This helps prevent duplicate submissions and gives clearer feedback to users.

## Summary by Sourcery

Improve exhibitor submission form UX by adding loading feedback during form submission to prevent duplicate submissions and provide clearer status to users.

New Features:
- Show a submission status message while the exhibitor form is being submitted.
- Disable the exhibitor form submit button and update its label to indicate an in-progress submission.