### PR TITLE
Make exhibitor status badge dynamic based on data

### DIFF
--- a/exhibition/templates/exhibitors/exhibitor_info.html
+++ b/exhibition/templates/exhibitors/exhibitor_info.html
@@ -55,7 +55,6 @@
                             {% endif %}
                         </td>
 
-                        <!-- ✅ FIXED STATUS LOGIC -->
                         <td>
                             {% if e.key %}
                                 <span class="label label-success">
@@ -75,11 +74,13 @@
                                     <i class="fa fa-edit"></i>
                                 </a>
 
-                                <a href="{% url "plugins:exhibition:copy_key" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}"
-                                   class="btn btn-default btn-sm"
-                                   title="{% trans "Key" %}" data-toggle="tooltip">
-                                    <i class="fa fa-copy"></i>
-                                </a>
+                                {% if e.key %}
+                                    <a href="{% url "plugins:exhibition:copy_key" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}"
+                                       class="btn btn-default btn-sm"
+                                       title="{% trans "Key" %}" data-toggle="tooltip">
+                                        <i class="fa fa-copy"></i>
+                                    </a>
+                                {% endif %}
 
                                 <a href="{% url "plugins:exhibition:delete" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}"
                                    class="btn btn-delete btn-danger btn-sm">

--- a/exhibition/templates/exhibitors/exhibitor_info.html
+++ b/exhibition/templates/exhibitors/exhibitor_info.html
@@ -3,6 +3,7 @@
 {% block title %}{% trans "Exhibitors" %}{% endblock %}
 {% block content %}
     <h1>{% trans "Exhibitors" %}</h1>
+
     {% if exhibitors|length == 0 %}
         <div class="empty-collection">
             <p>
@@ -13,49 +14,87 @@
 
             {% if "can_change_event_settings" in request.eventpermset %}
                 <a href="{% url "plugins:exhibition:add" organizer=request.event.organizer.slug event=request.event.slug %}"
-                        class="btn btn-primary btn-lg"><i class="fa fa-plus"></i> {% trans "Add Exhibitor" %}
+                   class="btn btn-primary btn-lg">
+                    <i class="fa fa-plus"></i> {% trans "Add Exhibitor" %}
                 </a>
             {% endif %}
         </div>
     {% else %}
+
         <p>
             {% if "can_change_event_settings" in request.eventpermset %}
-                <a href="{% url "plugins:exhibition:add" organizer=request.event.organizer.slug event=request.event.slug %}" class="btn btn-default"><i class="fa fa-plus"></i> {% trans "Add Exhibitor" %}
+                <a href="{% url "plugins:exhibition:add" organizer=request.event.organizer.slug event=request.event.slug %}"
+                   class="btn btn-default">
+                    <i class="fa fa-plus"></i> {% trans "Add Exhibitor" %}
                 </a>
             {% endif %}
         </p>
+
         <div class="table-responsive">
             <table class="table table-hover table-quotas">
                 <thead>
                 <tr>
                     <th>{% trans "Name" %}</th>
+                    <th>{% trans "Status" %}</th>
                     <th class="action-col-2"></th>
                 </tr>
                 </thead>
+
                 <tbody>
                 {% for e in exhibitors %}
                     <tr>
                         <td>
                             {% if "can_change_event_settings" in request.eventpermset %}
-                                <strong><a href="{% url "plugins:exhibition:edit" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}">
-                                    {{ e.name }}
-                                </a></strong>
+                                <strong>
+                                    <a href="{% url "plugins:exhibition:edit" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}">
+                                        {{ e.name }}
+                                    </a>
+                                </strong>
                             {% else %}
                                 <strong>{{ e.name }}</strong>
                             {% endif %}
                         </td>
-                        <td class="text-right flip">
-                            {% if "can_change_event_settings" in request.eventpermset %}
-                                <a href="{% url "plugins:exhibition:edit" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}" class="btn btn-default btn-sm"><i class="fa fa-edit"></i></a>
-                                <a href="{% url "plugins:exhibition:copy_key" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}" class="btn btn-default btn-sm" title="{% trans "Key" %}" data-toggle="tooltip"><i class="fa fa-copy"></i></a>
-                                <a href="{% url "plugins:exhibition:delete" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}" class="btn btn-delete btn-danger btn-sm"><i class="fa fa-trash"></i></a>
+
+                        <!-- ✅ FIXED STATUS LOGIC -->
+                        <td>
+                            {% if e.key %}
+                                <span class="label label-success">
+                                    {% trans "Approved" %}
+                                </span>
+                            {% else %}
+                                <span class="label label-warning">
+                                    {% trans "Pending Approval" %}
+                                </span>
                             {% endif %}
                         </td>
+
+                        <td class="text-right flip">
+                            {% if "can_change_event_settings" in request.eventpermset %}
+                                <a href="{% url "plugins:exhibition:edit" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}"
+                                   class="btn btn-default btn-sm">
+                                    <i class="fa fa-edit"></i>
+                                </a>
+
+                                <a href="{% url "plugins:exhibition:copy_key" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}"
+                                   class="btn btn-default btn-sm"
+                                   title="{% trans "Key" %}" data-toggle="tooltip">
+                                    <i class="fa fa-copy"></i>
+                                </a>
+
+                                <a href="{% url "plugins:exhibition:delete" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}"
+                                   class="btn btn-delete btn-danger btn-sm">
+                                    <i class="fa fa-trash"></i>
+                                </a>
+                            {% endif %}
+                        </td>
+
                     </tr>
                 {% endfor %}
                 </tbody>
             </table>
         </div>
+
     {% endif %}
+
     {% include "pretixcontrol/pagination.html" %}
 {% endblock %}


### PR DESCRIPTION
This PR improves the exhibitor list UI by making the status badge dynamic instead of hardcoded.

Previously, all exhibitors were shown as "Pending Approval", which was misleading. Now the status is derived from existing data (e.g., exhibitor key presence) to better reflect actual state.

This addresses the review feedback and improves overall UI accuracy.

## Summary by Sourcery

Make exhibitor list show a dynamic status column based on exhibitor data instead of a hardcoded label.

New Features:
- Add a status column to the exhibitor list that displays each exhibitor's current approval state.

Enhancements:
- Derive exhibitor status badges from the presence of an exhibitor key to reflect approved vs pending states.
- Tidy up exhibitor list template formatting and button markup for improved readability.