### PR TITLE
Move exhibitor status logic from template to model properties

### DIFF
--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -116,8 +116,8 @@ class ExhibitorInfo(models.Model):
 
     @property
     def is_approved(self):
-        return bool(self.key)
-
+        return self.key is not None and self.key != ""
+        
     @property
     def status_label(self):
         return _('Approved') if self.is_approved else _('Pending Approval')

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -114,6 +114,14 @@ class ExhibitorInfo(models.Model):
     def __str__(self):
         return str(self.name)
 
+    @property
+    def is_approved(self):
+        return bool(self.key)
+
+    @property
+    def status_label(self):
+        return _('Approved') if self.is_approved else _('Pending Approval')
+
 
 class Lead(models.Model):
     exhibitor = models.ForeignKey(


### PR DESCRIPTION
This PR refactors exhibitor status handling by moving approval and status-label logic into model properties.

Changes:
- Added is_approved property to ExhibitorInfo
- Added status_label property to ExhibitorInfo
- Keeps status-related logic out of the template for better separation of concerns

This makes the code cleaner, easier to maintain, and aligns better with review feedback.

## Summary by Sourcery

Move exhibitor approval and status-label logic from templates into the ExhibitorInfo model as computed properties.

New Features:
- Introduce an is_approved computed property on ExhibitorInfo to expose approval state.
- Add a status_label computed property on ExhibitorInfo to provide a user-facing approval status string.