### PR TITLE
Add linkedin_url field to ExhibitorInfo model

### DIFF
--- a/exhibition/api.py
+++ b/exhibition/api.py
@@ -53,8 +53,17 @@ class ExhibitorAuthView(views.APIView):
 class ExhibitorInfoSerializer(I18nAwareModelSerializer):
     class Meta:
         model = ExhibitorInfo
-        fields = ('id', 'name', 'description', 'url', 'email', 'logo', 'key', 'lead_scanning_enabled')
-
+        fields = (
+    'id',
+    'name',
+    'description',
+    'url',
+    'email',
+    'logo',
+    'key',
+    'lead_scanning_enabled',
+    'linkedin_url',   # ✅ ADD THIS
+)
 
 class ExhibitorInfoViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ExhibitorInfoSerializer

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -61,6 +61,7 @@ class ExhibitorInfo(models.Model):
         max_length=190,
         verbose_name=_('Name')
     )
+    linkedin_url = models.URLField(null=True, blank=True)
     description = I18nTextField(
         verbose_name=_('Description'),
         null=True,


### PR DESCRIPTION
## Description
Added a new optional field `linkedin_url` to the ExhibitorInfo model.

## Changes
Added linkedin_url field in ExhibitorInfo model

## Why
This allows exhibitors to link their LinkedIn profiles, improving networking and professional visibility.

## Notes
Migrations will be handled in the main project environment.

## Summary by Sourcery

New Features:
- Introduce an optional linkedin_url field on the ExhibitorInfo model to store exhibitors' LinkedIn profiles.