### PR TITLE
Add twitter_url and expose social links in ExhibitorInfo serializer

### DIFF
--- a/exhibition/api.py
+++ b/exhibition/api.py
@@ -53,7 +53,18 @@ class ExhibitorAuthView(views.APIView):
 class ExhibitorInfoSerializer(I18nAwareModelSerializer):
     class Meta:
         model = ExhibitorInfo
-        fields = ('id', 'name', 'description', 'url', 'email', 'logo', 'key', 'lead_scanning_enabled')
+        fields = (
+    'id',
+    'name',
+    'description',
+    'url',
+    'email',
+    'logo',
+    'key',
+    'lead_scanning_enabled',
+    'linkedin_url',   
+    'twitter_url',    
+)
 
 
 class ExhibitorInfoViewSet(viewsets.ReadOnlyModelViewSet):

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -61,6 +61,8 @@ class ExhibitorInfo(models.Model):
         max_length=190,
         verbose_name=_('Name')
     )
+    linkedin_url = models.URLField(null=True, blank=True)
+    twitter_url = models.URLField(null=True, blank=True)
     description = I18nTextField(
         verbose_name=_('Description'),
         null=True,


### PR DESCRIPTION
## Description
This PR adds optional social media fields (`linkedin_url`, `twitter_url`) to the ExhibitorInfo model and exposes them via the API serializer.

## Changes
- Added linkedin_url field to ExhibitorInfo model
- Added twitter_url field to ExhibitorInfo model
- Updated ExhibitorInfoSerializer to include both fields
- Added migration for database changes

## Impact
This improves exhibitor profiles by allowing integration of social media links, enhancing discoverability and engagement.

## Type
Enhancement