### PR TITLE
feat(exhibition): improve url field description for exhibitor

### DIFF
--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -67,7 +67,8 @@ class ExhibitorInfo(models.Model):
         blank=True
     )
     url = models.URLField(
-        verbose_name=_('URL'),
+        verbose_name=_('Company Website URL'),
+        help_text=_('Official website of the exhibitor'),
         null=True,
         blank=True
     )


### PR DESCRIPTION
## Description
Improved the exhibitor URL field by making it more descriptive.

## Changes
- Updated verbose_name to "Company Website URL"
- Added help_text for better clarity

## Impact
Improves usability and clarity for users managing exhibitor profiles.

## Summary by Sourcery

Clarify the exhibitor URL field labeling in the ExhibitorInfo model to better describe its purpose.

New Features:
- Add descriptive help text to the exhibitor URL field indicating it is the official website of the exhibitor.

Enhancements:
- Rename the exhibitor URL field label to 'Company Website URL' for clearer user-facing terminology.